### PR TITLE
Provides name and message per error case

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ var jwtLib = {
       jwt.setSigningAlgorithm(args.length === 3 ? alg : 'HS256');
       jwt.setSigningKey(secret);
     }
-    jwt.setExpiration((nowEpochSeconds() + (60 * 60)) * 1000); // one hour
+    jwt.setExpiration(claims.exp || (nowEpochSeconds() + (60 * 60)) * 1000); // one hour
     return jwt;
   }
 };

--- a/properties.json
+++ b/properties.json
@@ -1,10 +1,28 @@
 {
-  "errors": {
-      "PARSE_ERROR": "Jwt cannot be parsed",
-      "EXPIRED": "Jwt is expired",
-      "UNSUPPORTED_SIGNING_ALG": "Unsupported signing algorithm",
-      "SIGNING_KEY_REQUIRED": "Signing key is required",
-      "SIGNATURE_MISMTACH": "Signature verification failed",
-      "SIGNATURE_ALGORITHM_MISMTACH": "Unexpected signature algorithm"
-  }
+    "errors": {
+        "PARSE_ERROR": {
+            "name": "JwtParseError",
+            "message": "Jwt cannot be parsed"
+        },
+        "EXPIRED": {
+            "name": "JwtExpiredError",
+            "message": "Jwt is expired"
+        },
+        "UNSUPPORTED_SIGNING_ALG": {
+            "name": "UnsupportedAlgoError",
+            "message": "Unsupported signing algorithm"
+        },
+        "SIGNING_KEY_REQUIRED": {
+            "name": "SignKeyRequiredError",
+            "message": "Signing key is required"
+        },
+        "SIGNATURE_MISMTACH": {
+            "name": "SignatureMismatchError",
+            "message": "Signature verification failed"
+        },
+        "SIGNATURE_ALGORITHM_MISMTACH": {
+            "name": "UnexpectedSignatureAlgoError",
+            "message": "Unexpected signature algorithm"
+        }
+    }
 }


### PR DESCRIPTION
Major 1) Passes specific error name when creating instance of generic JwtParseError class.
Useful to end user to know precise error type and not just the message so he
can take additional action depending on it.
Major 2) create() respects user provided 'exp' timestamp in claims param over the default of one hour from now.
Minor: Indentation/formatting.