### PR TITLE
Fix so that missing fields are not added automatically when parsing JWT

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ Verifier.prototype.verify = function verify(jwtString,cb){
   }
 
 
-  var newJwt = new Jwt(body);
+  var newJwt = new Jwt(body, false);
 
   newJwt.toString = function(){ return jwtString;};
 

--- a/index.js
+++ b/index.js
@@ -126,20 +126,26 @@ JwtHeader.prototype.compact = function compact(){
   return base64urlEncode(JSON.stringify(this));
 };
 
-function Jwt(claims){
-
+function Jwt(claims, enforceDefaultFields){
   if(!(this instanceof Jwt)){
-    return new Jwt(claims);
+    return new Jwt(claims, enforceDefaultFields);
   }
+
   this.header = new JwtHeader();
-  this.setSigningAlgorithm('none');
   this.body = new JwtBody(claims);
-  if (!this.body.jti) {
-    this.setJti(uuid.v4());
+
+  if (enforceDefaultFields !== false) {
+    this.setSigningAlgorithm('none');
+
+    if (!this.body.jti) {
+      this.setJti(uuid.v4());
+    }
+
+    if (!this.body.iat) {
+      this.setIssuedAt(nowEpochSeconds());
+    }
   }
-  if (!this.body.iat) {
-    this.setIssuedAt(nowEpochSeconds());
-  }
+
   return this;
 }
 Jwt.prototype.setJti = function setJti(jti) {
@@ -266,7 +272,7 @@ Parser.prototype.parse = function parse(jwtString,cb){
   if(body instanceof Error){
     return done(new JwtParseError(properties.errors.PARSE_ERROR,jwtString,header,null));
   }
-  var jwt = new Jwt(body);
+  var jwt = new Jwt(body, false);
   jwt.setSigningAlgorithm(header.alg);
   jwt.signature = signature;
   jwt.verificationInput = segments[0] +'.' + segments[1];

--- a/test/builder.js
+++ b/test/builder.js
@@ -56,10 +56,20 @@ describe('create()',function(){
       var nowUnix = Math.floor(new Date().getTime()/1000);
       assert.equal(nJwt.create({},uuid()).body.iat , nowUnix);
     });
+
+    it('should not overwrite a defined iat field',function(){
+      assert.equal(nJwt.create({iat: 1},uuid()).body.iat , 1);
+    });
+
     it('should create the exp field, defaulted to 1 hour',function(){
       var oneHourFromNow = Math.floor(new Date().getTime()/1000) + (60*60);
       assert.equal(nJwt.create({},uuid()).body.exp , oneHourFromNow);
     });
+
+    it('should not overwrite a defined jti field',function(){
+      assert.equal(nJwt.create({jti: 1},uuid()).body.jti , 1);
+    });
+
     it('should create the jti field',function(){
       var jwt = nJwt.create({},uuid());
       assert(jwt.body.jti.match(/[a-zA-Z0-9]+[-]/));

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -25,9 +25,8 @@ describe('Verifier().setSigningAlgorithm() ',function(){
 });
 
 describe('.verify()',function(){
-
   it('should persist the original token to the toString() invocation',function(){
-    var token = new nJwt.Jwt({hello: uuid()}).setSigningAlgorithm('none').compact();
+    var token = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjMifQ.p6bizskaJLAheVyRhQEMR-60PkH_jtLVYgMy1qTjCoc';
     assert.equal(token,nJwt.verify(token).toString());
   });
 

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -30,6 +30,13 @@ describe('.verify()',function(){
     assert.equal(token,nJwt.verify(token).toString());
   });
 
+  it('should not alter the JWT, it should be compact-able as the same token',function(){
+    var orignalJwt = new nJwt.Jwt({hello: uuid()}, false).setSigningAlgorithm('none');
+    var originalToken = orignalJwt.compact();
+    var verifiedJwt = nJwt.verify(originalToken);
+    assert.equal(originalToken, verifiedJwt.compact());
+  });
+
   describe('if given only a token',function(){
     it('should verify tokens that are alg none',function(){
       var claims = {hello: uuid()};


### PR DESCRIPTION
Fixes so that missing fields (such as `typ`, `iat` and `jti`) are not automatically filled in when parsing a JWT.

#### How to verify

1. Use  `var jwt = nJwt.verify(token)` where token is a JWT without `iat` and `jti` fields.
2. Verify that the result is a JWT without these fields.
3. Verify that calling `jwt.toString()` yields the same result as the JWT you inserted.

Fixes #9