### PR TITLE
Fix encoding of ECDSA signatures

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-var crypto = require('crypto');
 var util = require('util');
-var properties = require('./properties.json');
 var uuid = require('uuid');
+var crypto = require('crypto');
+var ecdsaSigFormatter = require('ecdsa-sig-formatter');
+var properties = require('./properties.json');
 
 var algCryptoMap = {
   HS256: 'SHA256',
@@ -29,6 +30,10 @@ var algTypeMap = {
   ES384: 'sign',
   ES512: 'sign'
 };
+
+function isECDSA(algorithm) {
+  return algorithm.indexOf('ES') === 0;
+}
 
 function nowEpochSeconds(){
   return Math.floor(new Date().getTime()/1000);
@@ -185,24 +190,29 @@ Jwt.prototype.setSigningAlgorithm = function setSigningAlgorithm(alg) {
   return this;
 };
 
-Jwt.prototype.sign = function sign(payload, alg, cyrptoInput) {
+Jwt.prototype.sign = function sign(payload, algorithm, cryptoInput) {
   var buffer;
+  var signature;
+  var cryptoAlgName = algCryptoMap[algorithm];
+  var signingType = algTypeMap[algorithm];
 
-  var cryptoAlgName = algCryptoMap[alg];
-  var signingType = algTypeMap[alg];
-
-  if(cryptoAlgName){
-    if(signingType === 'hmac') {
-      buffer = crypto.createHmac(cryptoAlgName, cyrptoInput).update(payload).digest();
-    }
-    else{
-      buffer = crypto.createSign(cryptoAlgName).update(payload).sign(cyrptoInput);
-    }
-  }else{
+  if (!cryptoAlgName) {
     throw new JwtError(properties.errors.UNSUPPORTED_SIGNING_ALG);
   }
 
-  return base64urlEncode(buffer);
+  if (signingType === 'hmac') {
+    buffer = crypto.createHmac(cryptoAlgName, cryptoInput).update(payload).digest();
+  } else {
+    buffer = crypto.createSign(cryptoAlgName).update(payload).sign(cryptoInput);
+  }
+
+  if (isECDSA(algorithm)) {
+    signature = ecdsaSigFormatter.derToJose(buffer, algorithm);
+  } else {
+    signature = base64urlEncode(buffer);
+  }
+
+  return signature;
 };
 
 Jwt.prototype.isSupportedAlg = isSupportedAlg;
@@ -301,14 +311,13 @@ Verifier.prototype.setSigningKey = function setSigningKey(keyStr) {
 Verifier.prototype.isSupportedAlg = isSupportedAlg;
 
 Verifier.prototype.verify = function verify(jwtString,cb){
-
   var jwt;
 
   var done = handleError.bind(null,cb);
 
-  try{
+  try {
     jwt = new Parser().parse(jwtString);
-  }catch(e){
+  } catch(e) {
     return done(e);
   }
 
@@ -319,46 +328,53 @@ Verifier.prototype.verify = function verify(jwtString,cb){
   var cryptoAlgName = algCryptoMap[header.alg];
   var signingType = algTypeMap[header.alg];
 
-  if(header.alg!==this.signingAlgorithm){
+  if (header.alg !== this.signingAlgorithm) {
     return done(new JwtParseError(properties.errors.SIGNATURE_ALGORITHM_MISMTACH,jwtString,header,body));
   }
 
-  if(jwt.isExpired()){
+  if (jwt.isExpired()) {
     return done(new JwtParseError(properties.errors.EXPIRED,jwtString,header,body));
   }
 
-
   var digstInput = jwt.verificationInput;
-
   var verified, digest;
 
-  if(cryptoAlgName==='none'){
+  if( cryptoAlgName==='none') {
     verified = true;
-  }
-  else if(signingType === 'hmac') {
+  } else if(signingType === 'hmac') {
     digest = crypto.createHmac(cryptoAlgName, this.signingKey)
       .update(digstInput)
       .digest('base64');
-    verified = ( signature === digest );
-  }
-  else{
+    verified = signature === digest;
+  } else {
+    var unescapedSignature;
+    var signatureType = undefined;
+
+    if (isECDSA(header.alg)) {
+      unescapedSignature = ecdsaSigFormatter.joseToDer(signature, header.alg);
+    } else {
+      signatureType = 'base64';
+      unescapedSignature = base64urlUnescape(signature);
+    }
+
     verified = crypto.createVerify(cryptoAlgName)
       .update(digstInput)
-      .verify(this.signingKey, base64urlUnescape(signature), 'base64');
+      .verify(this.signingKey, unescapedSignature, signatureType);
   }
-
 
   var newJwt = new Jwt(body, false);
 
-  newJwt.toString = function(){ return jwtString;};
+  newJwt.toString = function () {
+    return jwtString;
+  };
 
   newJwt.header = new JwtHeader(header);
 
-  if ( verified ) {
-    return done(null,newJwt);
-  }else{
+  if (!verified) {
     return done(new JwtParseError(properties.errors.SIGNATURE_MISMTACH,jwtString,header,body));
   }
+
+  return done(null, newJwt);
 };
 
 var jwtLib = {
@@ -414,4 +430,5 @@ var jwtLib = {
     return jwt;
   }
 };
+
 module.exports = jwtLib;

--- a/index.js
+++ b/index.js
@@ -351,7 +351,11 @@ Verifier.prototype.verify = function verify(jwtString,cb){
     var signatureType = undefined;
 
     if (isECDSA(header.alg)) {
-      unescapedSignature = ecdsaSigFormatter.joseToDer(signature, header.alg);
+      try {
+        unescapedSignature = ecdsaSigFormatter.joseToDer(signature, header.alg);
+      } catch (err) {
+        return done(new JwtParseError(properties.errors.SIGNATURE_MISMTACH,jwtString,header,body));
+      }
     } else {
       signatureType = 'base64';
       unescapedSignature = base64urlUnescape(signature);

--- a/index.js
+++ b/index.js
@@ -74,12 +74,13 @@ function JwtError(message) {
 }
 util.inherits(JwtError, Error);
 
-function JwtParseError(message,jwtString,parsedHeader,parsedBody) {
+function JwtParseError(message,jwtString,parsedHeader,parsedBody,innerError) {
   this.name = 'JwtParseError';
   this.message = this.userMessage = message;
   this.jwtString = jwtString;
   this.parsedHeader = parsedHeader;
   this.parsedBody = parsedBody;
+  this.innerError = innerError;
 }
 util.inherits(JwtParseError, Error);
 
@@ -277,10 +278,10 @@ Parser.prototype.parse = function parse(jwtString,cb){
   }
 
   if(header instanceof Error){
-    return done(new JwtParseError(properties.errors.PARSE_ERROR,jwtString,null,null));
+    return done(new JwtParseError(properties.errors.PARSE_ERROR,jwtString,null,null,header));
   }
   if(body instanceof Error){
-    return done(new JwtParseError(properties.errors.PARSE_ERROR,jwtString,header,null));
+    return done(new JwtParseError(properties.errors.PARSE_ERROR,jwtString,header,null,body));
   }
   var jwt = new Jwt(body, false);
   jwt.setSigningAlgorithm(header.alg);
@@ -354,7 +355,7 @@ Verifier.prototype.verify = function verify(jwtString,cb){
       try {
         unescapedSignature = ecdsaSigFormatter.joseToDer(signature, header.alg);
       } catch (err) {
-        return done(new JwtParseError(properties.errors.SIGNATURE_MISMTACH,jwtString,header,body));
+        return done(new JwtParseError(properties.errors.SIGNATURE_MISMTACH,jwtString,header,body,err));
       }
     } else {
       signatureType = 'base64';

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/jwtk/njwt",
   "dependencies": {
+    "ecdsa-sig-formatter": "^1.0.5",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/test/algs.js
+++ b/test/algs.js
@@ -18,6 +18,7 @@ function testHmacAlg(alg,done){
   var token = jwt.compact();
 
   itShouldBeAValidJwt(jwt);
+
   nJwt.verify(token,key,alg,function(err,jwt){
     assert.isNull(err,'An unexpcted error was returned');
     itShouldBeAValidJwt(jwt);
@@ -26,12 +27,12 @@ function testHmacAlg(alg,done){
 }
 
 function testKeyAlg(alg,keyPair,done){
-
   var claims = { hello: uuid(), debug: true };
   var jwt = nJwt.create(claims,keyPair.private,alg);
   var token = jwt.compact();
 
   itShouldBeAValidJwt(jwt);
+
   nJwt.verify(token,keyPair.public,alg,function(err,jwt){
     assert.isNull(err,'An unexpcted error was returned');
     itShouldBeAValidJwt(jwt);


### PR DESCRIPTION
Fixes so that ECDSA signatures are formatted according to spec.

##### How to verify

1. Checkout and link this repo.
2. Create a new application using [this gist](https://gist.github.com/typerandom/66231538fce231a00674c072a92e24af).
3. Copy the keys `ecdsa.pub` and `ecdsa.priv` from `./test/` into your new application.
4. Run the application.
5. Verify that `VERIFIED ES512 JWT!` is written to console.
6. Open up `index.js` and modify the line `isECDSA(algorithm)` into `isECDSA(algorithm) && false`.
7. Run the application.
8. Verify that you get a `JwtParseError: Signature verification failed` error.
9. Revert the last change to the code you just changed, and jump to the next line with `isECDSA(header.alg)` and modify this into `isECDSA(header.alg) && false`.
10. Run the application.
11. Verify that you get a `JwtParseError: Signature verification failed` error.

Fixes #11