### PR TITLE
Expose the Parser to the public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,6 +366,7 @@ var jwtLib = {
   JwtBody: JwtBody,
   JwtHeader: JwtHeader,
   Verifier: Verifier,
+  Parser: Parser,
   base64urlEncode: base64urlEncode,
   base64urlUnescape:base64urlUnescape,
   verify: function(jwtString,secret,alg,cb){


### PR DESCRIPTION
Expose the Parser to the API for parsing of the header and body, without verification of the signature. See my issue #14 

Hope this follows the correct standards for this repo :)

Let me know if there are any issues with this