### PR TITLE
Implementing 'nbf' (Not Before) Claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ key to other systems.
 While the claims are completely up to you, we do recommend setting the "Subject"
 and "Audience" fields.
 
-JWTs commonly contain the `iat` and `exp` claims, which declare the time the
-token was issued and when it expires.  Our library will create these for you,
-with a default expiration of 1 hour.
+JWTs commonly contain the `iat`, `nbf` and `exp` claims, which declare the time the
+token was issued, activation date and when it expires.  Our library will create these for you (except nbf),
+with a default expiration of 1 hour. `nfb` is optional.
 
 Here is a simple example that shows you how to create a secure byte string for
 your signing key, and then use that key to sign a JWT with some claims that you
@@ -74,6 +74,7 @@ console.log(jwt);
     "jti": "c84280e6-0021-4e69-ad76-7a3fdd3d4ede",
     "iat": 1434660338,
     "exp": 1434663938,
+    "nbf": 1434663938,
     "iss": "http://myapp.com/",
     "sub": "users/user1234",
     "scope": ["self","admins"]
@@ -124,6 +125,7 @@ This library does the following checks when you call the `verify` method:
 * It was created by you (by verifying the signature, using the secret signing key)
 * It hasn't been modified (e.g. some claims were maliciously added)
 * It hasn't expired
+* It is active
 
 To verify a previously issued token, use the `verify` method.  You must give it
 the same signing key that you are using to create tokens:
@@ -200,6 +202,20 @@ var jwt = nJwt.create(claims,secret);
 jwt.setExpiration(new Date('2015-07-01')); // A specific date
 jwt.setExpiration(new Date().getTime() + (60*60*1000)); // One hour from now
 jwt.setExpiration(); // Remove the exp claim
+```
+
+#### NotBefore Claim
+
+A convenience method is supplied for modifying the `nbf` claim.  You can modify
+the `nbf` claim by passing a `Date` object, or a millisecond value, to the
+`setNotBefore` method:
+
+```javascript
+var jwt = nJwt.create(claims,secret);
+
+jwt.setNotbefore(new Date('2015-07-01')); // token is active from this date
+jwt.setNotbefore(new Date().getTime() + (60*60*1000)); // One hour from now
+jwt.setNotbefore(); // Remove the exp claim
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and "Audience" fields.
 
 JWTs commonly contain the `iat`, `nbf` and `exp` claims, which declare the time the
 token was issued, activation date and when it expires.  Our library will create these for you (except nbf),
-with a default expiration of 1 hour. `nfb` is optional.
+with a default expiration of 1 hour. `nbf` is optional.
 
 Here is a simple example that shows you how to create a secure byte string for
 your signing key, and then use that key to sign a JWT with some claims that you

--- a/index.js
+++ b/index.js
@@ -179,6 +179,15 @@ Jwt.prototype.setExpiration = function setExpiration(exp) {
 
   return this;
 };
+Jwt.prototype.setNotBefore = function setNotBefore(nbf) {
+  if(nbf) {
+    this.body.nbf = Math.floor((nbf instanceof Date ? nbf : new Date(nbf)).getTime() / 1000);
+  } else {
+    delete this.body.nbf;
+  }
+
+  return this;
+};
 Jwt.prototype.setSigningKey = function setSigningKey(key) {
   this.signingKey = key;
   return this;
@@ -244,6 +253,9 @@ Jwt.prototype.isExpired = function() {
   return new Date(this.body.exp*1000) < new Date();
 };
 
+Jwt.prototype.isNotBefore = function() {
+  return new Date(this.body.nbf * 1000) >= new Date();
+};
 
 function Parser(options){
   return this;
@@ -335,6 +347,10 @@ Verifier.prototype.verify = function verify(jwtString,cb){
 
   if (jwt.isExpired()) {
     return done(new JwtParseError(properties.errors.EXPIRED,jwtString,header,body));
+  }
+
+  if (jwt.isNotBefore()) {
+    return done(new JwtParseError(properties.errors.NOT_ACTIVE,jwtString,header,body));
   }
 
   var digstInput = jwt.verificationInput;

--- a/properties.json
+++ b/properties.json
@@ -5,6 +5,7 @@
       "UNSUPPORTED_SIGNING_ALG": "Unsupported signing algorithm",
       "SIGNING_KEY_REQUIRED": "Signing key is required",
       "SIGNATURE_MISMTACH": "Signature verification failed",
-      "SIGNATURE_ALGORITHM_MISMTACH": "Unexpected signature algorithm"
+      "SIGNATURE_ALGORITHM_MISMTACH": "Unexpected signature algorithm",
+      "NOT_ACTIVE": "Jwt not active"
   }
 }

--- a/test/jwt.js
+++ b/test/jwt.js
@@ -48,6 +48,33 @@ describe('Jwt',function() {
   });
 
 
+  describe('.setNotBefore()',function(){
+    it('should accept Date types and set the nbf claim to a UNIX timestamp value',function(){
+      var future = new Date('2025');
+      assert.equal(
+        nJwt.Jwt().setNotBefore(future).body.nbf,
+        future.getTime()/1000
+      );
+    });
+    it('should accept milliseconds values and set the nbf claim to a UNIX timestamp value',function(){
+      var future = new Date('2025').getTime();
+      assert.equal(
+        nJwt.Jwt().setNotBefore(future).body.nbf,
+        future/1000
+      );
+    });
+    it('should allow me to remove the nbf field',function(){
+      var jwt = nJwt.create({},uuid());
+      var oneHourFromNow = Math.floor(new Date().getTime()/1000) + (60*60);
+      assert.equal(nJwt.create({},uuid()).body.nbf , undefined);
+      assert.equal(jwt.setNotBefore().body.nbf, undefined);
+      assert.equal(jwt.setNotBefore(false).body.nbf, undefined);
+      assert.equal(jwt.setNotBefore(null).body.nbf, undefined);
+      assert.equal(jwt.setNotBefore(0).body.nbf, undefined);
+    });
+  });
+
+
   describe('.setSigningAlgorithm()',function(){
     it('should throw if you specify an alg but not a key',function(){
       assert.throws(function(){

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -126,6 +126,29 @@ describe('Verifier().verify() ',function(){
     });
   });
 
+  it('should return the jwt string, header and body on error objects with not active message',function(done){
+    var jwt = new nJwt.Jwt({notActiveToken:uuid()})
+      .setNotBefore(new Date().getTime()+1000);
+    var token = jwt.compact();
+    nJwt.verify(token,function(err){
+      assert.equal(err.jwtString,token);
+      assert.equal(err.parsedHeader.alg,jwt.header.alg);
+      assert.equal(err.parsedBody.notActiveToken,jwt.body.notActiveToken);
+      assert.equal(err.userMessage,properties.errors.NOT_ACTIVE);
+      done();
+    });
+  });
+
+  it('should return the jwt string, header and body with null error objects',function(done){
+    var jwt = new nJwt.Jwt({notActiveToken:uuid()});
+    var token = jwt.compact();
+    nJwt.verify(token,function(err){
+      assert.isNull(err);
+      assert.isNotNull(token);
+      done();
+    });
+  });
+
   describe('when configured to expect no verification',function(){
     var verifier = new nJwt.Verifier()
       .setSigningAlgorithm('none');
@@ -165,6 +188,25 @@ describe('Verifier().verify() ',function(){
       it('should return EXPIRED',function(){
         assert.isNotNull(result[0],'An error was not returned');
         assert.equal(result[0].userMessage,properties.errors.EXPIRED);
+      });
+    });
+
+    describe('and given a not active token',function(){
+      var result;
+      var jwt = new nJwt.Jwt({notActiveToken:'x'})
+        .setNotBefore(new Date().getTime()+1000);
+
+
+      before(function(done){
+        verifier.verify(jwt.compact(),function(err,res){
+          result = [err,res];
+          done();
+        });
+      });
+
+      it('should return NOT_ACTIVE',function(){
+        assert.isNotNull(result[0],'An error was not returned');
+        assert.equal(result[0].userMessage,properties.errors.NOT_ACTIVE);
       });
     });
 


### PR DESCRIPTION
Implementing https://tools.ietf.org/html/rfc7519#section-4.1.5

'The "nbf" (not before) claim identifies the time before which the JWT **MUST NOT** be accepted for processing.'

nbf is optional.