### PR TITLE
Fix package license to be a valid SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jwt"
   ],
   "author": "Stormpath, Inc.",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/jwtk/njwt/issues"
   },


### PR DESCRIPTION
Fixes so that the package version is a valid SPDX identifier (see https://spdx.org/licenses/Apache-2.0.html).

#### How to verify

1. Checkout the master branch.
2. Remove the `node_modules` directory.
3. Run `$ npm install`.
4. Verify that you see the warning `npm WARN njwt@0.3.1 license should be a valid SPDX license expression`.
5. Checkout this branch.
6. Remove the `node_modules` directory.
7. Run `$ npm install`.
8. Verify that you don't see the `npm WARN njwt@0.3.1 license should be a valid SPDX license expression` warning.