### PR TITLE
Update shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 "Nin-Jot" /ˈnɪn.dʒɑt/
 
 [![NPM Version](https://img.shields.io/npm/v/njwt.svg?style=flat)](https://npmjs.org/package/njwt)
-[![NPM Downloads](http://img.shields.io/npm/dm/njwt.svg?style=flat)](https://npmjs.org/package/njwt)
+[![NPM Downloads](https://img.shields.io/npm/dm/njwt.svg?style=flat)](https://npmjs.org/package/njwt)
 [![Build Status](https://img.shields.io/travis/jwtk/njwt.svg?style=flat)](https://travis-ci.org/jwtk/njwt)
 [![Coverage Status](https://coveralls.io/repos/jwtk/njwt/badge.svg?branch=master)](https://coveralls.io/r/jwtk/njwt?branch=master)
 


### PR DESCRIPTION
When pulling in the readme.md into jsonwebtoken.io, not having the shields image come from https breaks the tls validation.