### PR TITLE
Export Parser and test

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,9 @@ Jwt.prototype.isNotBefore = function() {
 };
 
 function Parser(options){
+  if(!(this instanceof Parser)){
+    return new Parser(options);
+  }
   return this;
 }
 
@@ -402,6 +405,7 @@ var jwtLib = {
   Jwt: Jwt,
   JwtBody: JwtBody,
   JwtHeader: JwtHeader,
+  Parser: Parser,
   Verifier: Verifier,
   base64urlEncode: base64urlEncode,
   base64urlUnescape:base64urlUnescape,

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,29 @@
+var assert = require('chai').assert;
+var uuid = require('uuid');
+var nJwt = require('../');
+
+
+describe('Parser', function () {
+  it('should construct itself if called without new', function () {
+    assert(nJwt.Parser() instanceof nJwt.Parser);
+  });
+});
+describe('Parser.parse()', function () {
+  var result = null
+  var claims = {hello: 'world'}
+  before(function(done){
+    var token = new nJwt.Jwt(claims, false)
+      .setSigningAlgorithm('none')
+      .compact();
+    var parser = nJwt.Parser();
+    parser.parse(token, function(err,res){
+        result = [err,res];
+        done();
+    });
+  });
+  it('should parse a valid token', function () {
+      assert.isNull(result[0], 'An error was not returned');
+      assert.equal(result[1].body.hello,claims.hello);
+  });
+
+});


### PR DESCRIPTION
In order to get access to the key id in the header for a key lookup, it would be helpful to have access to the parser.