### PR TITLE
Enable Key Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ none | No digital signature or MAC value included
     var claims = {hello: 'world'}
 
     var keys = [
-      {keyid: 'key1', secret: '12345'}, 
-      {keyid: 'key2',secret: 'abcd'}
+      {kid: 'key1', secret: '12345'}, 
+      {kid: 'key2',secret: 'abcd'}
     ];
     var currentKey = 0
 
@@ -249,13 +249,13 @@ none | No digital signature or MAC value included
     var token = new nJwt.Jwt(claims)
       .setSigningAlgorithm('HS256')
       .setSigningKey(keys[currentKey].secret)
-      .setSigningKeyId(keys[currentKey].keyid)
+      .setSigningkid(keys[currentKey].kid)
       .compact();
 
     // Parse the tokent
     var jwt = new nJwt.Parser().parse(token);
     // lookup the key
-    var found = keys.find(k => k.keyid === jwt.header.keyid)
+    var found = keys.find(k => k.kid === jwt.header.kid)
     // then verify
     var verifier = new nJwt.Verifier()
       .setSigningAlgorithm('HS256')

--- a/README.md
+++ b/README.md
@@ -234,9 +234,40 @@ ES384 | ECDSA using P-384 curve and SHA-384 hash algorithm
 ES512 | ECDSA using P-521 curve and SHA-512 hash algorithm
 none | No digital signature or MAC value included
 
+## Key Lookup
+
+```javascript
+    var claims = {hello: 'world'}
+
+    var keys = [
+      {keyid: 'key1', secret: '12345'}, 
+      {keyid: 'key2',secret: 'abcd'}
+    ];
+    var currentKey = 0
+
+    // create a token
+    var token = new nJwt.Jwt(claims)
+      .setSigningAlgorithm('HS256')
+      .setSigningKey(keys[currentKey].secret)
+      .setSigningKeyId(keys[currentKey].keyid)
+      .compact();
+
+    // Parse the tokent
+    var jwt = new nJwt.Parser().parse(token);
+    // lookup the key
+    var found = keys.find(k => k.keyid === jwt.header.keyid)
+    // then verify
+    var verifier = new nJwt.Verifier()
+      .setSigningAlgorithm('HS256')
+      .setSigningKey(found.secret)
+      .verify(token, function (err, res) {
+        if (res.body.hello !== claims.hello)
+          throw(new Error('lookup didnt work'))
+      });
+```
+
 ## Unsupported features
 
 The following features are not yet supported by this library:
 
 * Encrypting the JWT (aka JWE)
-* Signing key resolver (using the `kid` field)

--- a/index.js
+++ b/index.js
@@ -192,6 +192,11 @@ Jwt.prototype.setSigningKey = function setSigningKey(key) {
   this.signingKey = key;
   return this;
 };
+Jwt.prototype.setSigningKeyId = function setSigningKeyId(keyid) {
+  this.header.keyid = keyid;
+  return this;
+};
+
 Jwt.prototype.setSigningAlgorithm = function setSigningAlgorithm(alg) {
   if(!this.isSupportedAlg(alg)){
     throw new JwtError(properties.errors.UNSUPPORTED_SIGNING_ALG);

--- a/index.js
+++ b/index.js
@@ -258,6 +258,9 @@ Jwt.prototype.isNotBefore = function() {
 };
 
 function Parser(options){
+  if(!(this instanceof Parser)){
+    return new Parser(options);
+  }
   return this;
 }
 
@@ -402,6 +405,7 @@ var jwtLib = {
   Jwt: Jwt,
   JwtBody: JwtBody,
   JwtHeader: JwtHeader,
+  Parser: Parser,
   Verifier: Verifier,
   base64urlEncode: base64urlEncode,
   base64urlUnescape:base64urlUnescape,

--- a/index.js
+++ b/index.js
@@ -192,8 +192,8 @@ Jwt.prototype.setSigningKey = function setSigningKey(key) {
   this.signingKey = key;
   return this;
 };
-Jwt.prototype.setSigningKeyId = function setSigningKeyId(keyid) {
-  this.header.keyid = keyid;
+Jwt.prototype.setSigningKeyId = function setSigningKeyId(kid) {
+  this.header.kid = kid;
   return this;
 };
 

--- a/index.js
+++ b/index.js
@@ -331,12 +331,16 @@ Verifier.prototype.verify = function verify(jwtString,cb){
 
   var done = handleError.bind(null,cb);
 
-  try {
-    jwt = new Parser().parse(jwtString);
-  } catch(e) {
-    return done(e);
+  if (jwtString instanceof Jwt) {
+    jwt = jwtString;
+   // console.log(jwt)
+  } else {
+    try {
+      jwt = new Parser().parse(jwtString);
+    } catch(e) {
+      return done(e);
+    }
   }
-
   var body = jwt.body;
   var header = jwt.header;
   var signature = jwt.signature;

--- a/test/jwt.js
+++ b/test/jwt.js
@@ -84,11 +84,11 @@ describe('Jwt',function() {
   });
 
   describe('.setSigningKeyId()',function(){
-    it('should accept a keyid key',function(){
-      var keyid = '1234'
+    it('should accept a kid',function(){
+      var kid = '1234'
       var jwt = new nJwt.Jwt({}, false)
-        .setSigningKeyId(keyid);
-        assert.equal(jwt.header.keyid, keyid);
+        .setSigningKeyId(kid);
+        assert.equal(jwt.header.kid, kid);
     });
   });
 

--- a/test/jwt.js
+++ b/test/jwt.js
@@ -83,6 +83,15 @@ describe('Jwt',function() {
     });
   });
 
+  describe('.setSigningKeyId()',function(){
+    it('should accept a keyid key',function(){
+      var keyid = '1234'
+      var jwt = new nJwt.Jwt({}, false)
+        .setSigningKeyId(keyid);
+        assert.equal(jwt.header.keyid, keyid);
+    });
+  });
+
   describe('.sign()',function(){
     it('should throw if you give it an unknown algoritm',function(){
       assert.throws(function(){

--- a/test/key-lookup.js
+++ b/test/key-lookup.js
@@ -7,8 +7,8 @@ describe('demonstrate a key lookup on verify', function () {
     var result;
     var claims = {hello: 'world'}
     var keys = [
-      {keyid: 'key1', secret: '12345'}, 
-      {keyid: 'key2',secret: 'abcd'}
+      {kid: 'key1', secret: '12345'}, 
+      {kid: 'key2',secret: 'abcd'}
     ];
     var currentKey = 0
     var expectedSecret = keys[currentKey].secret
@@ -16,11 +16,11 @@ describe('demonstrate a key lookup on verify', function () {
     var token = new nJwt.Jwt(claims)
       .setSigningAlgorithm('HS256')
       .setSigningKey(expectedSecret)
-      .setSigningKeyId(keys[currentKey].keyid)
+      .setSigningKeyId(keys[currentKey].kid)
       .compact();
 
     var jwt = new nJwt.Parser().parse(token);
-    var found = keys.find(k => k.keyid === jwt.header.keyid)
+    var found = keys.find(k => k.kid === jwt.header.kid)
 
     assert.equal(found.secret, expectedSecret);
 
@@ -44,8 +44,8 @@ describe('demonstrate a key lookup on verify', function () {
     var claims = {hello: 'world'}
 
     var keys = [
-      {keyid: 'key1', secret: '12345'}, 
-      {keyid: 'key2',secret: 'abcd'}
+      {kid: 'key1', secret: '12345'}, 
+      {kid: 'key2',secret: 'abcd'}
     ];
     var currentKey = 0
 
@@ -53,13 +53,13 @@ describe('demonstrate a key lookup on verify', function () {
     var token = new nJwt.Jwt(claims)
       .setSigningAlgorithm('HS256')
       .setSigningKey(keys[currentKey].secret)
-      .setSigningKeyId(keys[currentKey].keyid)
+      .setSigningKeyId(keys[currentKey].kid)
       .compact();
 
     // Parse the tokent
     var jwt = new nJwt.Parser().parse(token);
     // lookup the key
-    var found = keys.find(k => k.keyid === jwt.header.keyid)
+    var found = keys.find(k => k.kid === jwt.header.kid)
     // then verify
     var verifier = new nJwt.Verifier()
       .setSigningAlgorithm('HS256')

--- a/test/key-lookup.js
+++ b/test/key-lookup.js
@@ -1,0 +1,73 @@
+var assert = require('chai').assert;
+var uuid = require('uuid');
+var nJwt = require('../');
+
+describe('demonstrate a key lookup on verify', function () {
+  describe('and given an signed token', function () {
+    var result;
+    var claims = {hello: 'world'}
+    var keys = [
+      {keyid: 'key1', secret: '12345'}, 
+      {keyid: 'key2',secret: 'abcd'}
+    ];
+    var currentKey = 0
+    var expectedSecret = keys[currentKey].secret
+
+    var token = new nJwt.Jwt(claims)
+      .setSigningAlgorithm('HS256')
+      .setSigningKey(expectedSecret)
+      .setSigningKeyId(keys[currentKey].keyid)
+      .compact();
+
+    var jwt = new nJwt.Parser().parse(token);
+    var found = keys.find(k => k.keyid === jwt.header.keyid)
+
+    assert.equal(found.secret, expectedSecret);
+
+    before(function (done) {
+      var verifier = new nJwt.Verifier()
+        .setSigningAlgorithm('HS256')
+        .setSigningKey(found.secret)
+      verifier.verify(token, function (err, res) {
+        result = [err, res];
+        done();
+      });
+    });
+
+    it('the jwt should be equal', function () {
+      assert.equal(result[1].body.hello, claims.hello);
+    });
+  });
+
+
+  describe('demo key lookup', function () {
+    var claims = {hello: 'world'}
+
+    var keys = [
+      {keyid: 'key1', secret: '12345'}, 
+      {keyid: 'key2',secret: 'abcd'}
+    ];
+    var currentKey = 0
+
+    // create a token
+    var token = new nJwt.Jwt(claims)
+      .setSigningAlgorithm('HS256')
+      .setSigningKey(keys[currentKey].secret)
+      .setSigningKeyId(keys[currentKey].keyid)
+      .compact();
+
+    // Parse the tokent
+    var jwt = new nJwt.Parser().parse(token);
+    // lookup the key
+    var found = keys.find(k => k.keyid === jwt.header.keyid)
+    // then verify
+    var verifier = new nJwt.Verifier()
+      .setSigningAlgorithm('HS256')
+      .setSigningKey(found.secret)
+      .verify(token, function (err, res) {
+        if (res.body.hello !== claims.hello)
+          throw(new Error('lookup didnt work'))
+      });
+  });
+
+});

--- a/test/parser.js
+++ b/test/parser.js
@@ -8,22 +8,36 @@ describe('Parser', function () {
     assert(nJwt.Parser() instanceof nJwt.Parser);
   });
 });
-describe('Parser.parse()', function () {
+
+describe('Parser.parse(token)', function () {
   var result = null
-  var claims = {hello: 'world'}
-  before(function(done){
+  var claims = { hello: 'world' }
+  var token = new nJwt.Jwt(claims, false)
+    .setSigningAlgorithm('none')
+    .compact();
+  it('should parse a valid token', function () {
+    var jwt = new nJwt.Parser().parse(token);
+    assert.equal(jwt.body.hello, claims.hello);
+  });
+
+});
+
+describe('Parser.parse(token, cb)', function () {
+  var result = null
+  var claims = { hello: 'world' }
+  before(function (done) {
     var token = new nJwt.Jwt(claims, false)
       .setSigningAlgorithm('none')
       .compact();
     var parser = nJwt.Parser();
-    parser.parse(token, function(err,res){
-        result = [err,res];
-        done();
+    parser.parse(token, function (err, res) {
+      result = [err, res];
+      done();
     });
   });
   it('should parse a valid token', function () {
-      assert.isNull(result[0], 'An error was not returned');
-      assert.equal(result[1].body.hello,claims.hello);
+    assert.isNull(result[0], 'An error was not returned');
+    assert.equal(result[1].body.hello, claims.hello);
   });
 
 });

--- a/test/parser.js
+++ b/test/parser.js
@@ -1,0 +1,29 @@
+var assert = require('chai').assert;
+var uuid = require('uuid');
+var nJwt = require('../');
+
+
+describe('Parser', function () {
+  it('should construct itself if called without new', function () {
+    assert(nJwt.Parser() instanceof nJwt.Parser);
+  });
+});
+describe('Parser.parse()', function () {
+  var result = null
+  var claims = {hello: 'world'}
+  before(function(done){
+    var token = new nJwt.Jwt(claims, false)
+      .setSigningAlgorithm('none')
+      .compact();
+    var parser = nJwt.Parser();
+    parser.parse(token, function(err,res){
+        result = [err,res];
+        done();
+    });
+  });
+  it('should parse a valid token', function () {
+      assert.isNull(result[0], 'An error was not returned');
+      assert.equal(result[1].body.hello,claims.hello);
+  });
+
+});

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -328,4 +328,27 @@ describe('Verifier().verify() ',function(){
       assert.equal(result[0].userMessage,properties.errors.SIGNATURE_MISMTACH);
     });
   });
+
+  describe('verify and existing Jwt object', function () {
+    var result = null
+    var claims = { hello: 'world' }
+
+    before(function(done){
+      var token = new nJwt.Jwt(claims, false)
+          .setSigningAlgorithm('none')
+          .compact();
+      var jwt = new nJwt.Parser().parse(token);
+      var verifier = new nJwt.Verifier()
+        .setSigningAlgorithm('none')
+      verifier.verify(jwt, function(err,res){
+        result = [err,res];
+        done();
+      });
+    });
+    it('should accept a valid Jwt as first param', function () {
+      assert.equal(result[1].body.hello, claims.hello);
+    });
+
+  });
+
 });

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -329,7 +329,7 @@ describe('Verifier().verify() ',function(){
     });
   });
 
-  describe('verify and existing Jwt object', function () {
+  describe('verify an existing Jwt object', function () {
     var result = null
     var claims = { hello: 'world' }
 


### PR DESCRIPTION
1. Export Parser.
2. Have Parser initialize its instance.
3. Add setSigningKeyId(kid) to Jwt.
4. Allow Verifier.verify to accept a Jwt in addition to a string token.
5. Tests for key-lookup, Parser and Verifier.
6. Edited Readme, to show how a key lookup could be implemented.
