### PR TITLE
Add key resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,53 @@ var jwt = nJwt.create({},secret);
 jwt.body.scope = 'admins';
 ````
 
+### Using a key resolver
+If your application is using multiple signing keys, nJwt provides a handy little
+feature that allows you to detect which signing key to use for token verification.
+
+You can pass a `keyResolver` function that will be passed the header `kid` field
+for inspection, if specified. You can then inspect the `kid` and return the signing
+key which should be used for verifying the JWT.
+
+The key resolver can be set on the verifier created via `nJwt.createVerifier`,
+using the `withKeyResolver` method. The verifier also exposes the `verify` method.
+Other than using a `keyResolver` when one is defined, it works the same as
+`nJwt.verify`:
+
+```javascript
+function myKeyResolver(kid, cb) {
+  if (kid === firstKid) {
+    return firstSigningKey;
+  }
+
+  return secondSigningKey;
+}
+
+var verifier =
+  nJwt.createVerifier().withKeyResolver(myKeyResolver);
+
+// synchronously
+try {
+  verifier.verify(token);
+} catch(e) {
+  console.log(e);
+}
+
+// asynchronously
+verifier.verify(token, function(err, verifiedJwt) {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log(verifiedJwt);
+});
+```
+
+The `keyResolver` function context (`this`) will be bound to the context of the
+`Verifier` used to verify the JWT. This means that if a `signingKey` is passed
+to the `verify` method as the second parameter, the `keyResolver` can access it
+as `this.signingKey`.
+
 #### Expiration Claim
 
 A convenience method is supplied for modifying the `exp` claim.  You can modify
@@ -239,4 +286,3 @@ none | No digital signature or MAC value included
 The following features are not yet supported by this library:
 
 * Encrypting the JWT (aka JWE)
-* Signing key resolver (using the `kid` field)

--- a/index.js
+++ b/index.js
@@ -327,7 +327,7 @@ Verifier.prototype.setSigningKey = function setSigningKey(keyStr) {
   return this;
 };
 Verifier.prototype.setKeyResolver = function setKeyResolver(keyResolver) {
-  this.keyResolver = keyResolver;
+  this.keyResolver = keyResolver.bind(this);
 };
 Verifier.prototype.isSupportedAlg = isSupportedAlg;
 

--- a/index.js
+++ b/index.js
@@ -420,6 +420,7 @@ function JwtVerifier() {
 
 JwtVerifier.prototype.withKeyResolver = function withKeyResolver(keyResolver) {
   this._keyResolver = keyResolver;
+  return this;
 }
 
 JwtVerifier.prototype.verify = function verify(jwtString,secret,alg,cb) {
@@ -432,7 +433,7 @@ JwtVerifier.prototype.verify = function verify(jwtString,secret,alg,cb) {
 
   var verifier = new Verifier();
 
-  if (typeof this.keyResolver === 'function') {
+  if (typeof this._keyResolver === 'function') {
     verifier.setKeyResolver(this._keyResolver);
   }
 
@@ -455,6 +456,7 @@ var jwtLib = {
   Jwt: Jwt,
   JwtBody: JwtBody,
   JwtHeader: JwtHeader,
+  JwtVerifier: JwtVerifier,
   Verifier: Verifier,
   base64urlEncode: base64urlEncode,
   base64urlUnescape:base64urlUnescape,

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -80,6 +80,42 @@ describe('JwtVerifier', function() {
         });
       });
     });
+
+    describe('passing the error from the keyResolver', function() {
+      var keyResolver;
+      var error;
+      var jwtToken;
+      var jwtVerifier;
+
+      beforeEach(function() {
+        error = new Error('key resolver error');
+        keyResolver = function(kid, cb) {
+          cb(error);
+        };
+
+        jwtVerifier = nJwt.createVerifier().withKeyResolver(keyResolver);
+        jwtToken = new nJwt.Jwt().setSigningAlgorithm('none').compact();
+      });
+
+      describe('synchronously', function() {
+        it('should throw the error', function() {
+          var verify = function() {
+            jwtVerifier.verify(jwtToken);
+          };
+
+          assert.throws(verify, error);
+        });
+      });
+
+      describe('asynchronously', function() {
+        it('should pass the error to the callback', function(done) {
+          jwtVerifier.verify(jwtToken, function(err) {
+            assert.equal(err, error);
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('keyResolver context', function() {

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -12,7 +12,7 @@ describe('njwt.createVerifier', function() {
 
 describe('JwtVerifier', function() {
   it('should construct itself if called without new', function() {
-    assert((new nJwt.JwtVerifier()) instanceof nJwt.JwtVerifier);
+    assert(nJwt.JwtVerifier() instanceof nJwt.JwtVerifier);
   });
 
   describe('.withKeyResolver()', function() {

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -1,0 +1,84 @@
+var uuid = require('uuid');
+var assert = require('chai').assert;
+
+var nJwt = require('../');
+
+describe('njwt.createVerifier', function() {
+  it('should create a JwtVerifier instance', function() {
+    var verifier = nJwt.createVerifier();
+    assert(verifier instanceof nJwt.JwtVerifier);
+  });
+});
+
+describe('JwtVerifier', function() {
+  it('should construct itself if called without new', function() {
+    assert((new nJwt.JwtVerifier()) instanceof nJwt.JwtVerifier);
+  });
+
+  describe('.withKeyResolver()', function() {
+    var resolver;
+
+    before(function() {
+      resolver = function() {};
+    });
+
+    it('should set the ._keyResolver', function() {
+      var jwtVerifier = new nJwt.JwtVerifier();
+      jwtVerifier.withKeyResolver(resolver);
+      assert(jwtVerifier._keyResolver === resolver);
+    });
+
+    it('should return the JwtVerifier', function() {
+      var jwtVerifier = new nJwt.JwtVerifier();
+      assert(jwtVerifier.withKeyResolver(function() {}) === jwtVerifier);
+    });
+  });
+
+  describe('.verify', function() {
+    describe('with key resolver set', function() {
+      var callCount;
+      var keyResolver;
+      var keyKid;
+      var signingKey;
+      var mutatedSigningKey;
+      var jwtVerifier;
+      var jwtToken;
+
+      beforeEach(function() {
+        callCount = 0;
+        keyKid = '123';
+        signingKey = uuid();
+        mutatedSigningKey = signingKey + uuid();
+        keyResolver = function(kid, cb) {
+          callCount++;
+          assert(kid === keyKid);
+          cb(null, signingKey);
+        };
+
+        jwtVerifier = nJwt.createVerifier().withKeyResolver(keyResolver);
+
+        var jwt = new nJwt.Jwt().setSigningAlgorithm('none');
+        jwt.header.kid = keyKid;
+        jwtToken = jwt.compact();
+      });
+
+      it('should work synchronously', function() {
+        var verify = function() {
+          jwtVerifier.verify(jwtToken, mutatedSigningKey, 'none');
+        };
+
+        assert.doesNotThrow(verify);
+        assert.equal(callCount, 1);
+      });
+
+      it('should work asynchronously', function(done) {
+        jwtVerifier.verify(jwtToken, mutatedSigningKey, 'none', function(err, token) {
+          assert.isNull(err);
+          assert.isNotNull(token);
+          assert.equal(callCount, 1);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -25,7 +25,7 @@ describe('JwtVerifier', function() {
     it('should set the ._keyResolver', function() {
       var jwtVerifier = new nJwt.JwtVerifier();
       jwtVerifier.withKeyResolver(resolver);
-      assert(jwtVerifier._keyResolver === resolver);
+      assert.isDefined(jwtVerifier._keyResolver);
     });
 
     it('should return the JwtVerifier', function() {

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -81,4 +81,28 @@ describe('JwtVerifier', function() {
       });
     });
   });
+
+  describe('keyResolver context', function() {
+    var signingKey;
+    var keyResolver;
+    var jwtVerifier;
+    var jwtToken;
+
+    before(function() {
+      signingKey = uuid();
+      keyResolver = function(kid, cb) {
+        assert.instanceOf(this, nJwt.Verifier);
+        cb(null, this.signingKey);
+      };
+
+      jwtVerifier = nJwt.createVerifier().withKeyResolver(keyResolver);
+      jwtToken = new nJwt.Jwt().setSigningAlgorithm('none').compact();
+    });
+
+    it('should be set to the Verifier instance', function(done) {
+      jwtVerifier.verify(jwtToken, signingKey, 'none', function() {
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds a key resolver, allowing the user to use different signing keys depending on the JWT header `kid` property. Adds tests for the key resolver. Adds documentation in the README.md for using the resolver.

Example:

```javascript
var token = 'eyJraWQiOiIyMzhCSFRDQTlXUzhEMTJOUkdMMU5OMVNGIiwic3R0IjoiYWNjZXNzIiwiYWxnIjoiSFMyNTYifQ.eyJqdGkiOiI2Y3dCTEZTQlZKRnpJYXlTYzRMd0I3IiwiaWF0IjoxNDg0NjM1MjM1LCJpc3MiOiJodHRwczovL2FwaS5zdG9ybXBhdGguY29tL3YxL2FwcGxpY2F0aW9ucy8yNGs3SG5ET3o0dFE5QVJzQnRQVU42Iiwic3ViIjoiaHR0cHM6Ly9hcGkuc3Rvcm1wYXRoLmNvbS92MS9hY2NvdW50cy81dThCWVp0dTA5czN5ZDFYdERZUlNvIiwiZXhwIjoxNDg0NjM1ODM1LCJydGkiOiI2Y3dCTEM4NmFpeDBmbHNiUG9VZlozIn0.obn4vi2eCp2Uv0vyTigKU6fklcAVhHxKcnLxoNvPOh4';

function resolver(kid, callback){

  console.log(kid); // 238BHTCA9WS8D12NRGL1NN1SF, using the token above

  // resolve a signing key
  callback(err, signingKey);
}

var verifier = nJwt.createVerifier().withKeyResolver(resolver);

try {
  verifier.verify(token);
} catch (err) {
  console.log(err);
}

// or

verifier.verify(token, callback);
```

Fixes #26 but uses slightly different syntax as to keep it simple and allow the same interface for both `nJwt.verify` and `verifier.verify`.