### PR TITLE
Corrects rsa documentation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ nJwt.verify(token,signingKey, 'HS512');
 ````
 
 See the table below for a list of supported algorithms.  If using RSA key pairs,
-the public key will be the signing key parameter.
+the private key will be the signing key parameter.
 
 ### Customizing the token
 


### PR DESCRIPTION
The documentation currently states to use the public key when signing a request. When using rsa, the private key should be used to sign the request.