### PR TITLE
Add option to pass a fully parsed JWT object to the key resolver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ verifier.verify(tokenB, function(err, verifiedJwt) {
 });
 ```
 
-
+By default the key resolver function is passed provided `kid` property of the JWT header, however, by setting the property `setResolveByJwt(true);` on the verifier the key resolver may be passed a fully parsed JWT object instead.
 
 #### Expiration Claim
 

--- a/index.js
+++ b/index.js
@@ -321,6 +321,7 @@ function Verifier(){
   }
   this.setSigningAlgorithm('HS256');
   this.setKeyResolver(defaultKeyResolver.bind(this));
+  this.keyResolveByJwt = false;
   return this;
 }
 Verifier.prototype.setSigningAlgorithm = function setSigningAlgorithm(alg) {
@@ -336,6 +337,10 @@ Verifier.prototype.setSigningKey = function setSigningKey(keyStr) {
 };
 Verifier.prototype.setKeyResolver = function setKeyResolver(keyResolver) {
   this.keyResolver = keyResolver.bind(this);
+};
+Verifier.prototype.setKeyResolveByJwt = function setResolveByJwt(keyResolveByJwt) {
+  this.keyResolveByJwt = keyResolveByJwt;
+  return this;
 };
 Verifier.prototype.isSupportedAlg = isSupportedAlg;
 
@@ -372,7 +377,9 @@ Verifier.prototype.verify = function verify(jwtString,cb){
   var digstInput = jwt.verificationInput;
   var verified, digest;
 
-  return this.keyResolver(header.kid, function(err, signingKey) {
+  var resolvable = this.keyResolveByJwt ? jwt : header.kid;
+
+  return this.keyResolver(resolvable, function(err, signingKey) {
 
     if (err) {
       return done(new JwtParseError(util.format(properties.errors.KEY_RESOLVER_ERROR, header.kid),jwtString,header,body, err));

--- a/test/key-resolver.js
+++ b/test/key-resolver.js
@@ -75,18 +75,21 @@ describe('Verifier', function() {
 
     describe('passing the error from the keyResolver', function() {
       var keyResolver;
+      var resolvableReceived;
       var error;
+      var jwt;
       var jwtToken;
       var jwtVerifier;
 
       beforeEach(function() {
         error = new Error('key resolver error');
-        keyResolver = function(kid, cb) {
+        keyResolver = function(resolvable, cb) {
+          resolvableReceived = resolvable;
           cb(error);
         };
 
         jwtVerifier = nJwt.createVerifier().withKeyResolver(keyResolver);
-        var jwt = new nJwt.create({},'foo');
+        jwt = new nJwt.create({},'foo');
         jwt.header.kid = 'foo'
         jwtToken = jwt.compact();
       });
@@ -111,6 +114,18 @@ describe('Verifier', function() {
           });
         });
       });
+
+      describe('key resolve by passing the parsed jwt as the resolvable', function() {
+        it('should throw the error', function() {
+          jwtVerifier.setKeyResolveByJwt(true);
+          var verify = function() {
+            jwtVerifier.verify(jwtToken);
+          };
+          assert.throws(verify, util.format(properties.errors.KEY_RESOLVER_ERROR, 'foo'));
+          assert.equal(resolvableReceived.body.jit, jwt.body.jit,);
+        });
+      });
+
     });
   });
 });


### PR DESCRIPTION
We have a use case where we need to resolve keys for JWTs from multiple issuers. Figured the most flexible solution was to provide the option pass a fully parsed JWT to the key resolver instead of just the `kid`.

Made this change backwards compatible so the the `kid` is passed still by default. A new setting on the Verifier controls this new behaviour. Added a test case and updated the README.md

Happy to clean up or change anything.