### PR TITLE
Fix uninitialised memory exposure vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function nowEpochSeconds(){
 }
 
 function base64urlEncode(data) {
-  const str = typeof data === 'number' ? data.toString() : data
+  const str = typeof data === 'number' ? data.toString() : data;
   return Buffer.from(str)
     .toString('base64')
     .replace(/\+/g, '-')

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ function nowEpochSeconds(){
   return Math.floor(new Date().getTime()/1000);
 }
 
-function base64urlEncode(str) {
-  return new Buffer(str)
+function base64urlEncode(data) {
+  const str = typeof data === 'number' ? data.toString() : data
+  return Buffer.from(str)
     .toString('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
@@ -277,7 +278,7 @@ Parser.prototype.isSupportedAlg = isSupportedAlg;
 Parser.prototype.safeJsonParse = function(input) {
   var result;
   try{
-    result = JSON.parse(new Buffer(base64urlUnescape(input),'base64'));
+    result = JSON.parse(Buffer.from(base64urlUnescape(input),'base64'));
   }catch(e){
     return e;
   }
@@ -297,7 +298,7 @@ Parser.prototype.parse = function parse(jwtString,cb){
   var body = this.safeJsonParse(segments[1]);
 
   if(segments[2]){
-    signature = new Buffer(base64urlUnescape(segments[2]),'base64')
+    signature = Buffer.from(base64urlUnescape(segments[2]),'base64')
       .toString('base64');
   }
 

--- a/test/builder.js
+++ b/test/builder.js
@@ -101,7 +101,7 @@ describe('base64 URL Encoding',function(){
     assert.equal(
       nJwt.Jwt.prototype.sign(
         [compactHeader,compactBody].join('.'),
-        'HS256',new Buffer(key,'base64')
+        'HS256',Buffer.from(key,'base64')
       ),
       expectedSignature
     );


### PR DESCRIPTION
This PR fixes the uninitialised memory / DoS vulnerability that occurs when sending numbers to  `base64urlEncode()`

https://snyk.io/vuln/npm:njwt:20180614
https://hackerone.com/reports/321704

Strictly speaking, casting numbers toString() when calling `new Buffer()` is all that is required but this PR also replaces the officially deprecated `new Buffer()` calls with `Buffer.from()` which should be compatible with all actively-supported Node versions.