### PR TITLE
Add NBF clock tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ try{
 }
 ````
 
+To allow clocktolerance use the third argument (in milliseconds):
+````javascript
+nJwt.verify(token, null, null, 2500, function(err,verifiedJwt){
+
+});
+````
+
 ### Changing the algorithm
 
 If you want to change the algorithm from the default `HS256`, you can do so

--- a/index.js
+++ b/index.js
@@ -266,8 +266,8 @@ Jwt.prototype.isExpired = function() {
   return new Date(this.body.exp*1000) < new Date();
 };
 
-Jwt.prototype.isNotBefore = function() {
-  return new Date(this.body.nbf * 1000) >= new Date();
+Jwt.prototype.isNotBefore = function(ms) {
+  return new Date((this.body.nbf * 1000) - ms) >= new Date();
 };
 
 function Parser(options){
@@ -322,6 +322,7 @@ function Verifier(){
   }
   this.setSigningAlgorithm('HS256');
   this.setKeyResolver(defaultKeyResolver.bind(this));
+  this.nbfTolerance = 0;
   return this;
 }
 Verifier.prototype.setSigningAlgorithm = function setSigningAlgorithm(alg) {
@@ -337,6 +338,10 @@ Verifier.prototype.setSigningKey = function setSigningKey(keyStr) {
 };
 Verifier.prototype.setKeyResolver = function setKeyResolver(keyResolver) {
   this.keyResolver = keyResolver.bind(this);
+};
+Verifier.prototype.setNbfTolerance = function setNbfTolerance(ms) {
+  this.nbfTolerance = ms;
+  return this;
 };
 Verifier.prototype.isSupportedAlg = isSupportedAlg;
 
@@ -366,7 +371,7 @@ Verifier.prototype.verify = function verify(jwtString,cb){
     return done(new JwtParseError(properties.errors.EXPIRED,jwtString,header,body));
   }
 
-  if (jwt.isNotBefore()) {
+  if (jwt.isNotBefore(this.nbfTolerance)) {
     return done(new JwtParseError(properties.errors.NOT_ACTIVE,jwtString,header,body));
   }
 
@@ -435,12 +440,28 @@ var jwtLib = {
   Verifier: Verifier,
   base64urlEncode: base64urlEncode,
   base64urlUnescape:base64urlUnescape,
-  verify: function(/*jwtTokenString, [signingKey], [algOverride], [callbck] */){
+  verify: function(/*jwtTokenString, [signingKey], [algOverride], [nbfTolerance], [callback] */){
 
     var args = Array.prototype.slice.call(arguments);
     var cb = typeof args[args.length-1] === 'function' ? args.pop() : null;
 
     var verifier = new Verifier();
+
+    if(args.length===4){
+      verifier.setNbfTolerance(args[3]);
+
+      if(args[2]==null){
+        verifier.setSigningAlgorithm('none');
+      }else{
+        verifier.setSigningAlgorithm(args[2]);
+      }
+
+      if(args[1]==null){
+        verifier.setSigningKey('');
+      }else{
+        verifier.setSigningKey(args[1]);
+      }
+    }
 
     if(args.length===3){
       verifier.setSigningAlgorithm(args[2]);

--- a/test/verifier.js
+++ b/test/verifier.js
@@ -148,6 +148,17 @@ describe('Verifier().verify() ',function(){
     });
   });
 
+  it('should NOT return the jwt string, header and body on error objects with not active message since nbfTolerance is set',function(done){
+    var jwt = new nJwt.Jwt({notActiveToken:uuid()})
+      .setNotBefore(new Date().getTime()+1000)
+    var token = jwt.compact();
+    nJwt.verify(token,null,null,1000,function(err){
+      assert.isNull(err);
+      assert.isNotNull(token);
+      done();
+    });
+  });
+
   it('should return the jwt string, header and body with null error objects',function(done){
     var jwt = new nJwt.Jwt({notActiveToken:uuid()});
     var token = jwt.compact();


### PR DESCRIPTION
Sometimes the server clock time differs between machines. That's why we needed some tolerance within the NBF. So I looked at [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) and implemented the same kind of functionality.

This fork fits our needs, but if we want to release this we probably want to change this part:
```
    if(args.length===4){
      verifier.setNbfTolerance(args[3]);

      if(args[2]==null){
        verifier.setSigningAlgorithm('none');
      }else{
        verifier.setSigningAlgorithm(args[2]);
      }

      if(args[1]==null){
        verifier.setSigningKey('');
      }else{
        verifier.setSigningKey(args[1]);
      }
    }
```

and
```
nJwt.verify(token,null,null,1000,function(err){
```


It's kind of ugly. Yet I don't know how to solve it without completely changing that function (without creating a breaking change).