### PR TITLE
Obvious Fix: Added "files" property to only include index.js / index.d.js in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/jwtk/njwt/issues"
   },
   "homepage": "https://github.com/jwtk/njwt",
+  "files": [
+    "index.js"
+  ],
   "dependencies": {
     "@types/node": "^15.0.1",
     "ecdsa-sig-formatter": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/jwtk/njwt",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "dependencies": {
     "@types/node": "^15.0.1",


### PR DESCRIPTION
My project uses a CI/CD security scanning tool for our node apps. This tool flagged the encryption keys in the `test/` folder of this library and would not allow us to publish the app. Our workaround was to `rm -rf node_modules/njwt/test` after `npm install` as part of our build step in the pipeline.

The security scanner is naive to the context of the encryption keys in `test/` and cannot see that those files won't actually be used by the apps that import this library.

However, since the `test/` files are not necessary to be included for consumers of this library, I believe the best solution is to only declare the files that are necessary. npm allows us to do this via the `files` property of `package.json`: https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files

This PR updates the `files` property of `package.json` to only include `index.js` and `index.d.ts`.

These other files from the library will always be included as part of the npm package, regardless of settings:

- package.json
- README.md
- CHANGELOG.md
- LICENSE