### PR TITLE
Make setExpiration argument optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ export declare class Jwt {
     setSubject(sub: string): Jwt;
     setIssuer(iss: string): Jwt;
     setIssuedAt(iat: number): Jwt;
-    setExpiration(exp: Date | number | string): Jwt;
+    setExpiration(exp?: Date | number | string): Jwt;
     setNotBefore(nbf: Date | number | string): Jwt;
     setSigningKey(key: string | Buffer): Jwt;
     signingKey: string | Buffer;


### PR DESCRIPTION
To accomplish the exp claim removal functionality described in the README,
I had to use `// @ts-ignore`. This brings the function signature in line
with its behavior.